### PR TITLE
Fix meteo data resampling when source and target start times are not in sync

### DIFF
--- a/openamundsen/fileio/meteo.py
+++ b/openamundsen/fileio/meteo.py
@@ -109,7 +109,13 @@ def read_meteo_data(
                 grid_crs,
             )
 
-        ds = _slice_and_resample_dataset(ds, start_date, end_date, freq, aggregate=aggregate)
+        ds = _slice_and_resample_dataset(
+            ds,
+            start_date,
+            end_date,
+            freq,
+            aggregate=aggregate,
+        )
 
         if ds.dims['time'] == 0:
             logger.warning('File contains no meteo data for the specified period')
@@ -273,12 +279,12 @@ def _slice_and_resample_dataset(ds, start_date, end_date, freq, aggregate=False)
     ds = ds.sel(time=slice(start_date, end_date))
 
     if inferred_freq is not None and inferred_freq != freq:
-        ds = _resample_dataset(ds, freq, aggregate=aggregate)
+        ds = _resample_dataset(ds, start_date, end_date, freq, aggregate=aggregate)
 
     return ds
 
 
-def _resample_dataset(ds, freq, aggregate=False):
+def _resample_dataset(ds, start_date, end_date, freq, origin=None, aggregate=False):
     """
     Resample a dataset to a given time frequency.
 
@@ -286,6 +292,12 @@ def _resample_dataset(ds, freq, aggregate=False):
     ----------
     ds : xr.Dataset
         Dataset.
+
+    start_date : datetime-like
+        Start date.
+
+    end_date : datetime-like
+        End date.
 
     freq : str
         Pandas-compatible frequency string (e.g. '3H'). Must be an exact subset
@@ -303,11 +315,15 @@ def _resample_dataset(ds, freq, aggregate=False):
     td = util.offset_to_timedelta(freq)
     td_1d = pd.Timedelta('1d')
     if td < td_1d:
-        resample_kwargs = dict(label='right', closed='right', origin='start')
+        resample_kwargs = dict(label='right', closed='right', origin=pd.Timestamp(start_date))
     elif td == td_1d:
         resample_kwargs = dict(label='left', closed='right', origin='start')
     else:
         raise errors.MeteoDataError('Resampling to frequencies > 1 day is not supported')
+
+    if ds.dims['time'] == 0:
+        # Nothing to resample
+        return ds
 
     # ds.resample() is extremely slow for some reason, so we resample using pandas
     df = ds.to_dataframe().drop(columns=['lon', 'lat', 'alt'])
@@ -320,17 +336,16 @@ def _resample_dataset(ds, freq, aggregate=False):
         if 'wind_dir' in df.columns:
             df_res['wind_dir'] = _aggregate_wind_dir(df, freq, resample_kwargs)
 
-        # We might end up with an extra bin after resampling; take only the dates which we would
-        # have taken when using instantaneous values
-        dates = df.asfreq(freq).index
-        if td == td_1d:
-            # When resampling from sub-daily to daily timesteps, df also includes the first timestep
-            # of the day after the end date
-            dates = dates[:-1]
-        df_res = df_res.loc[dates]
+        # We might end up with an extra bin after resampling; remove it here
+        df_res = df_res.loc[start_date:end_date]
     else:
         # Take the instantaneous values
-        df_res = df.asfreq(freq)
+        df_res = df.reindex(pd.date_range(
+            start=start_date,
+            end=end_date,
+            freq=freq,
+            name='time',
+        )).loc[df.index[0]:df.index[-1]]
 
     # Precipitation is summed up regardless of the aggregation setting
     if 'precip' in df:

--- a/openamundsen/fileio/pointoutput.py
+++ b/openamundsen/fileio/pointoutput.py
@@ -387,6 +387,11 @@ class PointOutputManager:
                     ds.to_netcdf(filename)
                 else:
                     with xr.open_dataset(filename) as old_ds:
+                        # Handle an issue introduced in xarray v2022.06.0 - without this line, the
+                        # time index somehow loses the time information and keeps only the date part
+                        # (triggered by test_point_output.py::test_write_freq)
+                        old_ds['time'] = old_ds.indexes['time']
+
                         ds_merge = xr.concat([old_ds, ds], 'time')
 
                     ds_merge.to_netcdf(filename)

--- a/tests/test_meteo_input.py
+++ b/tests/test_meteo_input.py
@@ -607,3 +607,25 @@ def test_non_hourly_input(tmp_path):
     ds2 = model.meteo
 
     xr.testing.assert_allclose(ds1, ds2)
+
+
+@pytest.mark.parametrize('aggregate', [False, True])
+def test_resample_with_non_matching_start_date(aggregate, tmp_path):
+    ds = xr.load_dataset(f'{pytest.DATA_DIR}/meteo/rofental/netcdf/proviantdepot.nc')
+    ds = ds.sel(time=slice('2020-11-03 02:00', None))
+    ds.to_netcdf(tmp_path / 'proviantdepot.nc')
+
+    p_orig = Path(f'{pytest.DATA_DIR}/meteo/rofental/netcdf')
+    for station_id in ('bellavista', 'latschbloder'):
+        (tmp_path / f'{station_id}.nc').symlink_to(p_orig / f'{station_id}.nc')
+
+    config = base_config()
+    config.start_date = '2020-11-01'
+    config.end_date = '2020-11-30'
+    config.timestep = '3H'
+    config.input_data.meteo.dir = str(tmp_path)
+    config.input_data.meteo.aggregate_when_downsampling = aggregate
+
+    model = oa.OpenAmundsen(config)
+    model.initialize()
+    assert model.meteo.indexes['time'].equals(model.dates)


### PR DESCRIPTION
e.g., when the original (hourly) dataset starts at 02:00, but the model start date is 00:00 with 3-hourly timesteps, before the fix _resample_dataset() would return a dataset resampled to dates 02:00, 05:00, …, instead of 00:00, 03:00, …