### PR TITLE
Fix dask.array import

### DIFF
--- a/openamundsen/fileio/griddedoutput.py
+++ b/openamundsen/fileio/griddedoutput.py
@@ -8,7 +8,7 @@ import pyproj
 import xarray as xr
 
 try:
-    import dask
+    import dask.array
     _DASK_AVAILABLE = True
 except ImportError:
     _DASK_AVAILABLE = False


### PR DESCRIPTION
Change `import dask` to `import dask.array` in fileio/griddedoutput.py (up to now this still worked, because dask.array used to be imported in xarray < 2022.11.0).