### PR TITLE
Allow compression of gridded output

### DIFF
--- a/openamundsen/data/configschema.yml
+++ b/openamundsen/data/configschema.yml
@@ -143,8 +143,8 @@ output_data:
         append: # when using NetCDF output, append data instead of creating a full-size dataset beforehand
           type: boolean
           default: true
-        
-        compress_output:
+
+        compress_output: # compress netcdf output grids with zlib/compression level 1
           type: boolean
           default: false
 

--- a/openamundsen/data/configschema.yml
+++ b/openamundsen/data/configschema.yml
@@ -143,6 +143,10 @@ output_data:
         append: # when using NetCDF output, append data instead of creating a full-size dataset beforehand
           type: boolean
           default: true
+        
+        compress_output:
+          type: boolean
+          default: false
 
         variables:
           type: list

--- a/openamundsen/data/configschema.yml
+++ b/openamundsen/data/configschema.yml
@@ -144,7 +144,7 @@ output_data:
           type: boolean
           default: true
 
-        compress_output: # compress netcdf output grids with zlib/compression level 1
+        compress: # compress output grids with zlib/compression level 1
           type: boolean
           default: false
 

--- a/openamundsen/data/configschema.yml
+++ b/openamundsen/data/configschema.yml
@@ -144,7 +144,7 @@ output_data:
           type: boolean
           default: true
 
-        compress: # compress output grids with zlib/compression level 1
+        compress: # compress output grids
           type: boolean
           default: false
 

--- a/openamundsen/fileio/griddedoutput.py
+++ b/openamundsen/fileio/griddedoutput.py
@@ -125,7 +125,6 @@ class GriddedOutputManager:
         self.fields = fields
         self.format = config.format
         self.nc_file_created = False
-        self.compress_output = config.compress_output
         self.data = None
 
     def update(self):
@@ -466,10 +465,10 @@ class GriddedOutputManager:
             if f'{time_var}_bounds' in ds:
                 ds[f'{time_var}_bounds'].encoding['dtype'] = np.float64
 
-        if self.compress_output:
+        if self.model.config.output_data.grids.compress:
             for data_var in ds.data_vars:
-                ds[data_var].encoding["zlib"] = True
-                ds[data_var].encoding["complevel"] = 1
+                ds[data_var].encoding['zlib'] = True
+                ds[data_var].encoding['complevel'] = 1
 
         return ds
 

--- a/openamundsen/fileio/griddedoutput.py
+++ b/openamundsen/fileio/griddedoutput.py
@@ -239,6 +239,9 @@ class GriddedOutputManager:
                             'crs': self.model.grid.crs,
                         }
 
+                        if self.model.config.output_data.grids.compress:
+                            rio_meta['compress'] = 'lzw'
+
                     if field.agg is None:
                         date_str = f'{date:%Y-%m-%dT%H%M}'
                     else:

--- a/openamundsen/fileio/griddedoutput.py
+++ b/openamundsen/fileio/griddedoutput.py
@@ -125,6 +125,7 @@ class GriddedOutputManager:
         self.fields = fields
         self.format = config.format
         self.nc_file_created = False
+        self.compress_output = config.compress_output
         self.data = None
 
     def update(self):
@@ -464,6 +465,11 @@ class GriddedOutputManager:
             ds[time_var].encoding['dtype'] = np.float64
             if f'{time_var}_bounds' in ds:
                 ds[f'{time_var}_bounds'].encoding['dtype'] = np.float64
+
+        if self.compress_output:
+            for data_var in ds.data_vars:
+                ds[data_var].encoding["zlib"] = True
+                ds[data_var].encoding["complevel"] = 1
 
         return ds
 


### PR DESCRIPTION
Hi there,

I added an option to allow for compression of netcdf gridded output. Maybe that's interesting for other users as well. The flag could also be propagated for writing compressed geotiffs, if needed.
Since this might introduce some overhead when writing files, it could be turned off by default.

Best,
Andreas