### PR TITLE
Require pytest < 8.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ liveview =
 test =
     dask
     pooch
-    pytest
+    pytest < 8.0 # because of https://github.com/TvoroG/pytest-lazy-fixture/issues/65
     pytest-lazy-fixture
     pvlib
 


### PR DESCRIPTION
because of https://github.com/TvoroG/pytest-lazy-fixture/issues/65