### PR TITLE
Remove superfluous loop in idw interpolation

### DIFF
--- a/openamundsen/interpolation.py
+++ b/openamundsen/interpolation.py
@@ -42,12 +42,9 @@ def _idw(x_points, y_points, z_points, x_targets, y_targets, power, smoothing):
                 break
 
             w += 1.0 / dist**power
+            total += z_points[k] / dist**power
 
         if not dist_is_0:
-            for k in range(num_points):
-                dist = np.sqrt((x - x_points[k]) ** 2 + (y - y_points[k]) ** 2 + smoothing**2)
-                total += z_points[k] / dist**power
-
             data[target_num] = total / w
 
     return data


### PR DESCRIPTION
Hi,

I had a look at the idw function because I wanted to adapt it for a personal use-case (non-metric features) and found that the second for loop is redundant. I think it can be safely removed (if I haven't missed anything :smiley: ).

Since I had some data at hand, I put together a performance check  with two test cases (you could check it out and run it from here: https://github.com/geopanda1/idw-performance) that interpolate ~ 19000 points from ~ 800 and ~12 points (the latter to simulate a number of meteorological stations, which I guess is the most common use case in openAmundsen (?))

Improvement in terms of runtime varies, but often is on the order of 30-40 %.

All the best
Andreas
